### PR TITLE
Add support for custom post type layout template overrides

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ get_header(); ?>
 
 							<?php
 							// Get post entry content
-							get_template_part( 'partials/entry/layout' ); ?>
+							get_template_part( 'partials/entry/layout', get_post_type() ); ?>
 
 							<?php
 							// Reset counter to clear floats

--- a/search.php
+++ b/search.php
@@ -27,7 +27,7 @@ get_header(); ?>
 
 						<?php while ( have_posts() ) : the_post(); ?>
 
-							<?php get_template_part( 'partials/entry/layout' ); ?>
+							<?php get_template_part( 'partials/entry/layout', get_post_type() ); ?>
 
 						<?php endwhile; ?>
 

--- a/singular.php
+++ b/singular.php
@@ -45,7 +45,7 @@ get_header(); ?>
 					// All other post types.
 					else {
 
-    					get_template_part( 'partials/single/layout' );
+    					get_template_part( 'partials/single/layout', get_post_type() );
 
   					}
 


### PR DESCRIPTION
Allow child themes to define a `partials/single/layout-my_cpt.php` file to handle custom post type layouts separately.