### PR TITLE
Better Specification for h2 titles

### DIFF
--- a/assets/css/woo/woocommerce.css
+++ b/assets/css/woo/woocommerce.css
@@ -1771,7 +1771,7 @@
   margin: 1.5em 0 0;
 }
 
-.woocommerce div.product .woocommerce-tabs .panel h2 {
+.woocommerce div.product .woocommerce-tabs .panel > h2:first-child {
   margin: 20px 0;
   font-size: 18px;
   font-weight: normal;


### PR DESCRIPTION
Rule was overwriting other h2 elements by being too specific. With this change, the rule will target only the intentioned titles: "Description" and so on...