### PR TITLE
Allow search in menu with medium header

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1531,7 +1531,6 @@ if ( ! function_exists( 'oceanwp_add_search_to_menu' ) ) {
 		if ( ! $search_style
 			|| 'disabled' == $search_style
 			|| 'top' == $header_style
-			|| 'medium' == $header_style
 			|| 'vertical' == $header_style ) {
 			return $items;
 		}


### PR DESCRIPTION
The search icon in menu works with medium header, but you disabled the possibility. I am reactivating it again.