### PR TITLE
Fix social template not displayed

### DIFF
--- a/partials/header/social.php
+++ b/partials/header/social.php
@@ -54,7 +54,7 @@ if ( 'simple' != $style ) {
 $inner_classes = implode( ' ', $inner_classes );
 
 // Return if there aren't any profiles defined and define var
-if ( ! $profiles = get_theme_mod( 'ocean_menu_social_profiles' ) ) {
+if ( ( ! $profiles = get_theme_mod( 'ocean_menu_social_profiles' ) ) && empty( $get_content ) ) {
 	return;
 }
 


### PR DESCRIPTION
Fix social template not displayed if social profiles are empty. The template should be displayed even if the social profiles are not set.