### PR TITLE
Hook to allow customization of single product

### DIFF
--- a/woocommerce/owp-single-product.php
+++ b/woocommerce/owp-single-product.php
@@ -44,5 +44,7 @@ foreach ( $elements as $element ) {
 	if ( 'meta' == $element ) {
 		woocommerce_template_single_meta();
 	}
+	
+	do_action( 'ocean_after_single_product_'.$element );
 
 }


### PR DESCRIPTION
Hello

Ocean removes all the WooCommerce hooks attached to `woocommerce_single_product_summary` and replaces it with a single hook `single_product_content`.

At the moment it is not possible to insert content between, for example the title and the price.

My suggestion is adding an action after every element of this page.

Thank you