### PR TITLE
Add compatibility with WooCommerce Mix and Match

### DIFF
--- a/assets/js/third/woo/devs/wooQuantityButtons.js
+++ b/assets/js/third/woo/devs/wooQuantityButtons.js
@@ -62,8 +62,9 @@ function oceanwpWooQuantityButtons( $quantitySelector ) {
 			// If floating bar is enabled
 			if ( $j( 'body' ).hasClass( 'single-product' )
 				&& 'on' == oceanwpLocalize.floating_bar
-				&& ! $cart.hasClass( 'grouped_form' ) ) {
-				$quantityBox = $j( '.plus, .minus' ).closest( '.quantity' ).find( $quantitySelector );
+				&& ! $cart.hasClass( 'grouped_form' )
+				&& ! $cart.hasClass( 'cart_group' ) ) {
+				$quantityBox = $j( '.plus, .minus' ).closest( '.quantity' ).find( $quantitySelector ).first();
 			} else {
 				$quantityBox = $j( this ).closest( '.quantity' ).find( $quantitySelector );
 			}


### PR DESCRIPTION
Compatibility with Product Bundles and Composite Products should come automatically since we all use the same `cart_group` class. Closes #139.