### PR TITLE
Suggested Page 404 language strings to improvements (English & French)

### DIFF
--- a/languages/fr_FR.po
+++ b/languages/fr_FR.po
@@ -24,17 +24,17 @@ msgstr ""
 
 #: 404.php:103
 msgid "This page could not be found!"
-msgstr "Oups, cette page n’existe pas !"
+msgstr "Oups, cette page est introuvable !"
 
 #: 404.php:104
 msgid "We are sorry. But the page you are looking for is not available."
-msgstr "Nous sommes désolés, mais la page que vous cherchez n’existe plus."
+msgstr "Nous sommes désolés, mais la page que vous cherchez n’est pas disponnible."
 
 #: 404.php:104
 #, fuzzy
 #| msgid "Perhaps you can try a new searching."
-msgid "Perhaps you can try a new search."
-msgstr "Peut-être vous pouvez essayer une nouvelle recherche."
+msgid "If this page does exist, you may need to log in to see it. Otherwise, you can try to look for it via a search."
+msgstr "Si cette page existe bien, il est possible que vous ayez besoin de vous connecter pour y accéder. Sinon, vous pouvez la chercher par une recherche."
 
 #: 404.php:106
 msgid "Back To Homepage"


### PR DESCRIPTION
Hi,

The language strings of the page 404 need some improvements.

    #: 404.php:103
    msgid "This page could not be found!"
    msgstr "Oups, cette page n’existe pas !"

The French translation is not in line with the English version and misleading.
The page may exist and just not be available for the user for a question of rights or because he's just not connected.
The strict translation of the English version is more neutral...
msgstr "Oups, cette page est introuvable !

    #: 404.php:104
    msgid "We are sorry. But the page you are looking for is not available."
    msgstr "Nous sommes désolés, mais la page que vous cherchez n’existe plus."

The French translation is not in line with the English version and misleading.
It now even suggests the page has existed but has been deleted!?
While the URL may just never has existed or once again, the page may still exist but just not be available for the user rights or because he's not connected.
Here again, the strict translation of the English version is more neutral...
msgstr "Nous sommes désolés, mais la page que vous cherchez n’est pas disponnible.

    #: 404.php:104
    #, fuzzy
    #| msgid "Perhaps you can try a new searching."
    msgid "Perhaps you can try a new search."
    msgstr "Peut-être vous pouvez essayer une nouvelle recherche."

It's indeed fuzzy. Even the English version.
It suggests we ended up here via a search (while it's most of the time not the case) as it suggests to try a "new" search; and it's not helping in case it's just a question of rights or being connected or not.
So I suggest...
msgid "If this page does exist, you may need to log in to see it. Otherwise, you can try to look for it via a search."
msgstr "Si cette page existe bien, il est possible que vous ayez besoin de vous connecter pour y accéder. Sinon, vous pouvez la chercher par une recherche."

Thanks.