### PR TITLE
Correct CSS on overlay search close button

### DIFF
--- a/inc/customizer/settings/header.php
+++ b/inc/customizer/settings/header.php
@@ -4804,7 +4804,7 @@ if ( ! class_exists( 'OceanWP_Header_Customizer' ) ) :
 
 			// Search overlay close button color
 			if ( ! empty( $search_overlay_close_button_color ) && '#ffffff' != $search_overlay_close_button_color ) {
-				$css .= '.search-overlay .search-toggle-li .search-overlay-toggle.exit > span:before{color:'. $search_overlay_close_button_color .';}';
+				$css .= '#searchform-overlay a.search-overlay-close span::before, #searchform-overlay a.search-overlay-close span::after{background-color:'. $search_overlay_close_button_color .';}';
 			}
 
 			// Links effect blue color


### PR DESCRIPTION
##Problem:
With Ocean WP as theme, in Customize > header > menu, select:
- Search Icon Style: Overlay;
- Overlay Background color: white (for example);
- Close button color: purple (for example).

This doesn't change the CSS as it should. This is because the CSS selector and property are both wrong.

##Solution
This pull request specifies the correct CSS selector and corrects the property from color to background-color.