### PR TITLE
Fix product quantities syncing incorrectly for Mix and Match products

### DIFF
--- a/assets/js/third/woo/devs/wooQuantityButtons.js
+++ b/assets/js/third/woo/devs/wooQuantityButtons.js
@@ -44,7 +44,8 @@ function oceanwpWooQuantityButtons( $quantitySelector ) {
 		// Quantity input
 		if ( $j( 'body' ).hasClass( 'single-product' )
 			&& 'on' == oceanwpLocalize.floating_bar
-			&& ! $cart.hasClass( 'grouped_form' ) ) {
+			&& ! $cart.hasClass( 'grouped_form' )
+			&& ! $cart.hasClass( 'cart_group' ) ) {
 			var $quantityInput = $j( '.woocommerce form input[type=number].qty' );
 			$quantityInput.on( 'keyup', function() { 
 				var qty_val = $j( this ).val();


### PR DESCRIPTION
syncing quantity inputs from the top bar to the rest of the inputs is incompatible with the Mix and Match products plugin.

The result is that typing in one of the quantity inputs syncs the quantity across all the inputs.

https://share.getcloudapp.com/QwuGr1x5

More details here:

https://wordpress.org/support/topic/product-quantities-syncing-incorrectly-for-mix-and-match-products/
