### PR TITLE
(fix) remove wrong double slash

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -530,7 +530,7 @@ final class OCEANWP_Theme_Class {
 	 * @since 1.0.0
 	 */
 	public static function html5_shiv() {
-		wp_register_script( 'html5shiv', OCEANWP_JS_DIR_URI . '/third/html5.min.js', array(), OCEANWP_THEME_VERSION, false );
+		wp_register_script( 'html5shiv', OCEANWP_JS_DIR_URI . 'third/html5.min.js', array(), OCEANWP_THEME_VERSION, false );
 		wp_enqueue_script( 'html5shiv' );
 		wp_script_add_data( 'html5shiv', 'conditional', 'lt IE 9' );
 	}


### PR DESCRIPTION
Fix /wp-content/themes/oceanwp/assets/js//third/html5.min.js?ver=1.0 link