### PR TITLE
Product archive pages show <br> tags in product titles.

### DIFF
--- a/woocommerce/owp-archive-product-hover.php
+++ b/woocommerce/owp-archive-product-hover.php
@@ -63,7 +63,7 @@ do_action( 'ocean_before_archive_product_title' );
 
 echo '<li class="title">';
 	do_action( 'ocean_before_archive_product_title_inner' );
-	echo '<a href="' . esc_url( get_the_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
+	echo '<a href="' . esc_url( get_the_permalink() ) . '">' . wp_kses_post( get_the_title() ) . '</a>';
 	do_action( 'ocean_after_archive_product_title_inner' );
 echo '</li>';
 

--- a/woocommerce/owp-archive-product.php
+++ b/woocommerce/owp-archive-product.php
@@ -56,7 +56,7 @@ foreach ( $elements as $element ) {
 
 		echo '<li class="title">';
 			do_action( 'ocean_before_archive_product_title_inner' );
-			echo '<a href="' . esc_url( get_the_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
+			echo '<a href="' . esc_url( get_the_permalink() ) . '">' . wp_kses_post( get_the_title() ) . '</a>';
 			do_action( 'ocean_after_archive_product_title_inner' );
 		echo '</li>';
 


### PR DESCRIPTION
50d1a0a4292efea16ee1231d89a119f2654cb3ed encodes the `<br>` tag as html entities so they are displayed in the title text.
521555ddc05fda20b8fe2ac2d444830529cc3c0e modified the filter to make more sense but didn't fix our issue.

I understand that sanitizing data is important but esc_att and esc_html break the common use of tags such as <br> in product titles.

As a compromise I would ask that this be backed down to wp_kses_post level of filtering. 