### PR TITLE
Fixed fatal error on product page

### DIFF
--- a/inc/woocommerce/woocommerce-helpers.php
+++ b/inc/woocommerce/woocommerce-helpers.php
@@ -139,7 +139,9 @@ if ( ! function_exists( 'oceanwp_woo_product_instock' ) ) {
 		global $post;
 		$post_id      = $post_id ? $post_id : $post->ID;
 		$product = wc_get_product($post_id);
-		return $product->is_in_stock();
+		//return $product->is_in_stock(); // returns error if product not found and wc_get_product() returns boolean
+		
+		return $product ? $product->is_in_stock() : false;
 	}
 
 }


### PR DESCRIPTION
Fixes PHP Fatal error:  Uncaught Error: Call to a member function is_in_stock() on bool in /var/app/current/wp-content/themes/oceanwp/inc/woocommerce/woocommerce-helpers.php:142