### PR TITLE
bugfix blocker PHP Parse error

### DIFF
--- a/inc/template-helpers.php
+++ b/inc/template-helpers.php
@@ -345,7 +345,7 @@ if ( ! function_exists( 'ocean_get_post_author_avatar' ) ) {
 			$author_id,
 			apply_filters( 'ocean_author_bio_avatar_size', $args['size'] ),
 			'',
-			esc_attr( $args['alt'] ),
+			esc_attr( $args['alt'] )
 		);
 		$avatar_url .= '</a>';
 


### PR DESCRIPTION
fix: PHP Parse error:  syntax error, unexpected ')' in /mysite/public_html/wp-content/themes/oceanwp/inc/template-helpers.php on line 349
found on WordPress 5.9.3,  PHP (7.2.10-0ubuntu0.18.04.1)