### PR TITLE
fix prev button not working due to validation #380

### DIFF
--- a/assets/src/js/wp-plugins/woocommerce/woo-multi-step-checkout.js
+++ b/assets/src/js/wp-plugins/woocommerce/woo-multi-step-checkout.js
@@ -117,7 +117,7 @@ class WooMultiStepCheckout {
     let prevStep = currentStep - 1;
     const isLoggedIn = options.is_logged_in;
 
-    if (!this.#formValidate(this.#steps[currentStep])) return;
+    if (action !== 'prev' && !this.#formValidate(this.#steps[currentStep])) return;
 
     this.#elements.checkoutTimeline
       .querySelectorAll(".active")


### PR DESCRIPTION
fix for issue https://github.com/oceanwp/oceanwp/issues/380