### PR TITLE
Change default value of $count to 0

### DIFF
--- a/partials/header/style/medium-header.php
+++ b/partials/header/style/medium-header.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $elements = oceanwp_medium_header_elements();
 
 // Define counter.
-$count = '';
+$count = 0;
 
 // Bottom header class.
 $classes = array( 'bottom-header-wrap', 'clr' );


### PR DESCRIPTION
Found during the analysis of: https://wiki.php.net/rfc/saner-inc-dec-operators

The default empty string is never used and gets converted to string ``"1"`` on the first iteration and then to integer ``2`` on the second one.

The type juggling back from int to string is not affected.

https://github.com/oceanwp/oceanwp/blob/master/inc/customizer/settings/typography.php#L486
is not affected because the ``$count`` variable is initialized to ``"1"``.